### PR TITLE
Support one-line CDATA

### DIFF
--- a/src/PrettyXml/Formatter.php
+++ b/src/PrettyXml/Formatter.php
@@ -108,6 +108,9 @@ class Formatter
      */
     private function runPost($part)
     {
+        if ($this->isOpeningCdataTag($part) && $this->isClosingCdataTag($part)) {
+            return;
+        }
         if ($this->isOpeningTag($part)) {
             $this->depth++;
         }


### PR DESCRIPTION
The formatter should preserve indentation properly when the CDATA is closed on the same line where it is opened.

Test XML:

```xml
<Order><OrderNumber>B12345678</OrderNumber><BillingAddress><Name><![CDATA[John Doe]]></Name></BillingAddress></Order>
```

Output:

```xml
   <Order>
       <OrderNumber>B12345678</OrderNumber>
       <BillingAddress>
           <Name>
               <![CDATA[John Doe]]>
   </Name>
   </BillingAddress>
   </Order>
```

Expected output:

```xml
   <Order>
       <OrderNumber>B12345678</OrderNumber>
       <BillingAddress>
           <Name>
               <![CDATA[John Doe]]>
           </Name>
       </BillingAddress>
   </Order>
```